### PR TITLE
Update manifest for continuity with SynclerRepository

### DIFF
--- a/scraper.json
+++ b/scraper.json
@@ -1,8 +1,8 @@
 {
   "_manifest" : {
-    "name": "Syncler USDG Express",
-    "id": "syncler.usdg.express",
-    "version": 2,
+    "name": "Aki07 - Unified",
+    "id": "aki.unified.express",
+    "version": 3,
     "classPath": "",
     "permaUrl": "https://raw.githubusercontent.com/itzAki07/scraper/main/scraper.json"
   },

--- a/scraper.json
+++ b/scraper.json
@@ -1,7 +1,7 @@
 {
   "_manifest" : {
     "name": "Aki07 - Unified",
-    "id": "aki.unified.express",
+    "id": "aki.unified",
     "version": 3,
     "classPath": "",
     "permaUrl": "https://raw.githubusercontent.com/itzAki07/scraper/main/scraper.json"


### PR DESCRIPTION
This temporary manifest change fixes continuity between repositories and the package name itself.